### PR TITLE
Update jquery.loadTemplate.js

### DIFF
--- a/dist/jquery.loadTemplate.js
+++ b/dist/jquery.loadTemplate.js
@@ -319,6 +319,10 @@
             $elem.attr("alt", applyFormatters($elem, value, "alt", settings));
         });
 
+        processElements("data-title", template, data, settings, function ($elem, value) {
+            $elem.attr("title", applyFormatters($elem, value, "title", settings));
+        });
+
         processElements("data-id", template, data, settings, function ($elem, value) {
             $elem.attr("id", applyFormatters($elem, value, "id", settings));
         });


### PR DESCRIPTION
Added 'data-title' support.

The 'alt' attribute was supported for <img> elements, this adds support for the 'title' attribute on <a> elements.
Possible work around is:  data-template-bind='[{"attribute": "title", "value": "title"}]' but clutters the template if used a lot.